### PR TITLE
don't line wrap long strings

### DIFF
--- a/src/Config/Pretty.hs
+++ b/src/Config/Pretty.hs
@@ -56,7 +56,7 @@ showFrac radix x = intToDigit w : rest
       | otherwise = ""
 
 prettyText :: String -> Doc
-prettyText = doubleQuotes . cat . snd . mapAccumL ppChar True
+prettyText = doubleQuotes . hcat . snd . mapAccumL ppChar True
 
   where ppChar s x
           | isDigit x = (True, if not s then text "\\&" <> char x else char x)


### PR DESCRIPTION
Previously:

```
*Config T> print . pretty . Text () $ T.replicate 66 (T.pack "a")
"a
 a
 a
 a
 a
 a
 a
 a
 a
 a
 a
 a
 a
 a
 a
 a
 a
 a
 a
 a
 a
 a
 a
 a
 a
 a
 a
 a
 a
 a
 a
 a
 a
 a
 a
 a
 a
 a
 a
 a
 a
 a
 a
 a
 a
 a
 a
 a
 a
 a
 a
 a
 a
 a
 a
 a
 a
 a
 a
 a
 a
 a
 a
 a
 a
 a"
```

Besides being pretty hilarious, this isn't actually a valid config-value file.

I looked briefly into whether I could make an `fcat` variant that inserted string gap markers, but it looks like it would require modifying the `pretty` library, so for now this change simply eliminates newlines inside quoted strings entirely.