### PR TITLE
haskell-ci.yml: try to fix node20 glibc mismatch

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -23,7 +23,7 @@ jobs:
     timeout-minutes:
       60
     container:
-      image: buildpack-deps:bionic
+      image: buildpack-deps:focal
     continue-on-error: ${{ matrix.allow-failure }}
     strategy:
       matrix:


### PR DESCRIPTION
ubuntu:20.04 is focal so try that for buildpack-deps

This is to fix: https://github.com/glguy/config-value/actions/runs/10949184645/job/30401853700
```
Run actions/checkout@v3
/usr/bin/docker exec  8f6e793bdab35a403b58198eaf1369624e6f8fc706ca491d621d31d67f16767b sh -c "cat /etc/*release | grep ^ID"
/__e/node20/bin/node: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by /__e/node20/bin/node)
```
Though I really don't know if it is sufficient: I see other [haskell-ci](https://github.com/haskell-CI/haskell-ci?tab=readme-ov-file) projects using `buildpack-deps:jammy` 🤷🏻